### PR TITLE
Update for tornado 6

### DIFF
--- a/baiocas/client.py
+++ b/baiocas/client.py
@@ -36,7 +36,7 @@ class Client(object):
 
     MINIMUM_BAYEUX_VERSION = '0.9'
 
-    def __init__(self, url, io_loop=None, **options):
+    def __init__(self, url, **options):
 
         # Set up a logger for the client
         self.log = logging.getLogger('%s.%s' % (self.__module__, self.__class__.__name__))
@@ -44,8 +44,8 @@ class Client(object):
         # Save the URL
         self._url = url
 
-        # Use the default IO loop if not provided
-        self.io_loop = io_loop or IOLoop.instance()
+        # Use the default IO loop
+        self.io_loop = IOLoop.current()
 
         # Current client status and connection properties
         self._status = ClientStatus.UNCONNECTED
@@ -795,7 +795,7 @@ class Client(object):
             self.log.debug('Exited batch context manager')
 
 
-def get_client(url, io_loop=None, **options):
-    client = Client(url, io_loop=io_loop, **options)
-    client.register_transport(LongPollingHttpTransport(io_loop=io_loop))
+def get_client(url, **options):
+    client = Client(url, **options)
+    client.register_transport(LongPollingHttpTransport())
     return client

--- a/baiocas/transports/base.py
+++ b/baiocas/transports/base.py
@@ -1,8 +1,6 @@
 import logging
 import urllib.parse
 
-from tornado.ioloop import IOLoop
-
 from baiocas import errors
 from baiocas.channel_id import ChannelId
 from baiocas.message import Message
@@ -14,9 +12,8 @@ class Transport(object):
 
     OPTION_MAXIMUM_NETWORK_DELAY = 'maximum_network_delay'
 
-    def __init__(self, io_loop=None, **options):
+    def __init__(self, **options):
         self.log = logging.getLogger('%s.%s' % (self.__module__, self.name))
-        self.io_loop = io_loop or IOLoop.instance()
         self._client = None
         self._options = {}
         self.url = None

--- a/baiocas/transports/long_polling.py
+++ b/baiocas/transports/long_polling.py
@@ -9,6 +9,8 @@ from baiocas import errors
 from baiocas.message import Message
 from baiocas.transports.http import HttpTransport
 
+from asyncio.futures import Future
+
 
 class LongPollingHttpTransport(HttpTransport):
 
@@ -135,7 +137,7 @@ class LongPollingHttpTransport(HttpTransport):
             except HTTPError:
                 response = self._blocking_http_client._response
         else:
-            response = yield gen.Task(self._http_client.fetch, request)
+            response = yield self._http_client.fetch(request)
 
         # Handle the response. We catch all exceptions here so that a bad
         # response doesn't end up crashing the Tornado async framework.

--- a/baiocas/transports/long_polling.py
+++ b/baiocas/transports/long_polling.py
@@ -9,8 +9,6 @@ from baiocas import errors
 from baiocas.message import Message
 from baiocas.transports.http import HttpTransport
 
-from asyncio.futures import Future
-
 
 class LongPollingHttpTransport(HttpTransport):
 

--- a/baiocas/transports/long_polling.py
+++ b/baiocas/transports/long_polling.py
@@ -32,7 +32,7 @@ class LongPollingHttpTransport(HttpTransport):
         # Can't use ModuleNotFoundError because it was added in Python 3.6
         except ImportError:
             pass
-        self._http_client = AsyncHTTPClient(io_loop=self.io_loop)
+        self._http_client = AsyncHTTPClient()
         self._blocking_http_client = HTTPClient(
             async_client_class=AsyncHTTPClient
         )

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'tornado>3.0'
+        'tornado>=6.0'
     ],
     extras_require={
         'pycurl': ['pycurl>=7.22.0'],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os import path
 from setuptools import find_packages
 from setuptools import setup
 
-version = '1.0.3'
+version = '2.0.0'
 
 here = path.abspath(path.dirname(__file__))
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -237,7 +237,7 @@ class TestClient(AsyncTestCase):
         assert not channel_2.has_subscriptions
         channel_1.notify_listeners(channel_1, self.mock_message)
         channel_2.notify_listeners(channel_2, self.mock_message)
-        mock_listener.called_with(channel_1, self.mock_message)
+        mock_listener.assert_called_with(channel_1, self.mock_message)
         assert not mock_subscription.called
 
     def test_configure(self):

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -158,7 +158,8 @@ class TestClient(AsyncTestCase):
 
     def setUp(self):
         self.io_loop = self.get_new_ioloop()
-        self.client = Client('http://www.example.com', io_loop=self.io_loop)
+        self.client = Client('http://www.example.com')
+        self.client.io_loop = self.io_loop
         self.transport = MockTransport('mock-transport')
         self.client.register_transport(self.transport)
         self.mock_message = Message(channel='/test', data='dummy')


### PR DESCRIPTION
Tornado 6 removed the `io_loop` parameter, which removed the ability to create and pass in your own instance of it. This PR makes baiocas compatible with tornado 6 by removing the ability to create or pass in IOLoops to tornado. For code that runs functions on IOLoops created the old way, `IOLoop.current()` is used to get the current instance instead.

Tornado 6 also removed the `Task` function ([deprecated](https://github.com/tornadoweb/tornado/blob/647aed6fc812e4f9fdc5a82a0675a4402ff9035b/tornado/gen.py#L638) in v5), which adapted callback-based functions to be used in coroutines. `Task` was used to call `AsyncHTTPClient.fetch` and get a `Future` instance. However,`fetch` in v6 removed the `callback` argument and returns a `Future` instance directly ([documentation](https://github.com/tornadoweb/tornado/blob/master/tornado/httpclient.py#L269-L277)), so this PR changes baiocas to just call the function directly and use its return value.

Test cases pass.